### PR TITLE
ensure impl passes a+ and trigger event once per leaf

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "build": "rollup -c",
     "build-test": "rollup -c rollup.config.test.js",
     "pretravis-test-browser": "npm run build-test",
-    "travis-test-browser": "zuul -- dist-test/index.js"
+    "travis-test-browser": "zuul -- dist-test/index.js",
+    "test-aplus": "npm run build && promises-aplus-tests test/adapter"
   },
   "dependencies": {},
   "devDependencies": {
     "babel-preset-env": "^1.3.3",
+    "promises-aplus-tests": "^2.1.2",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "tape": "^4.6.3",

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,0 +1,20 @@
+// This is the adapter for A+ compliance test suite
+
+const Promise = require('../dist/bundle.cjs').default;
+
+module.exports = {
+  resolveed(value) {
+    return Promise.resolve(value);
+  },
+  rejected(reason) {
+    return Promise.reject(reason);
+  },
+  deferred() {
+    let resolve, reject;
+    const promise = new Promise((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+    return {promise, resolve, reject};
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -57,3 +57,22 @@ test('rejection of non-error works', t => {
     window.removeEventListener('unhandledrejection', listener);
   }, 0);
 });
+
+
+test('does not trigger event for recovered downstream', t => {
+  t.plan(1);
+  let count = 0;
+  const reason = 'rejection';
+  const listener = (e) => {
+    count++;
+  }
+  window.addEventListener('unhandledrejection', listener);
+  auto();
+  const promise = Promise.reject(reason);
+  promise.catch(() => {}).then(() => {});
+  //macro-task(setTimeout) runs after microtask (Promise.resolve)
+  setTimeout(() => {
+    t.equal(count, 0, 'handler is not called');
+    window.removeEventListener('unhandledrejection', listener);
+  }, 0);
+});


### PR DESCRIPTION
Motivation: prior to this PR, this polyfill incorrectly errored when `.then()` was called without a second argument. In addition, it incorrectly triggered the event for every `.then()` call, rather than once per leaf

This PR ensures the polyfill is in fact A+ compliant, and fixes the rate of event firing to match that of Chrome.