### PR TITLE
Add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "bugs": "https://github.com/rtsao/browser-unhandled-rejection/issues",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",
+  "files": [
+    "dist/bundle.cjs.js",
+    "dist/bundle.es.js"
+  ],
   "scripts": {
     "prepublish": "npm run build",
     "pretest": "npm run build-test",


### PR DESCRIPTION
This PR makes its npm package a bit small. We need just the files in `/dist`.